### PR TITLE
fix: Ensure model/instance-ties BaseApi has default-converters from

### DIFF
--- a/xmodel/base/api.py
+++ b/xmodel/base/api.py
@@ -380,6 +380,7 @@ class BaseApi(Generic[M]):
         if model:
             # If we have a model, the structure should be exactly the same as it's BaseModel type.
             self._structure = api.structure
+            self.default_converters = api.default_converters
             self._api_state = PrivateApiState(model=model)
             return
 


### PR DESCRIPTION
Class-tied BaseApi object.

For now keeping this simple to get a quick-fix out, will soon change it to grab these dynamically from class-based BaseApi object, to take into account any dynamically changed default-converters.

Will add extra unit tests at that time.